### PR TITLE
Add support for Haiku lights 

### DIFF
--- a/Examples/fastDimLights.js
+++ b/Examples/fastDimLights.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../");
 
 // Don't scan for any fans since we know the exact address of the fan (faster!)
 var myMaster = new bigAssApi.FanMaster(0); 

--- a/Examples/fastDimLights.js
+++ b/Examples/fastDimLights.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 
 // Don't scan for any fans since we know the exact address of the fan (faster!)
 var myMaster = new bigAssApi.FanMaster(0); 

--- a/Examples/fastDimLights.js
+++ b/Examples/fastDimLights.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 
 // Don't scan for any fans since we know the exact address of the fan (faster!)
 var myMaster = new bigAssApi.FanMaster(0); 

--- a/Examples/getFanInfo.js
+++ b/Examples/getFanInfo.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 

--- a/Examples/getFanInfo.js
+++ b/Examples/getFanInfo.js
@@ -1,8 +1,8 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 
-var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
+var myMaster = new bigAssApi.FanMaster(1); // Expect only one device in my setup
 
-myMaster.onFanFullyUpdated = function(myBigAss){
-	console.log("Found a new fan with name '" + myBigAss.name + "'")
+myMaster.onDeviceFullyUpdated = function(myBigAss){
+	console.log("Found a new device with name '" + myBigAss.name + "'")
 	console.log("and identifier: '" + myBigAss.id + "'\n")
 }

--- a/Examples/getFanInfo.js
+++ b/Examples/getFanInfo.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 

--- a/Examples/largerExample.js
+++ b/Examples/largerExample.js
@@ -1,10 +1,10 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 bigAssApi.logging = false;
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 
 console.log("Waiting for full update");
-myMaster.onFanFullyUpdated = function(myBigAss){
+myMaster.onDeviceFullyUpdated = function(myBigAss){
 
     // Filter out all fants that don't begin with "Sean" - that's in my fan's name!
 	var lowercaseName = myBigAss.name.toLowerCase();

--- a/Examples/largerExample.js
+++ b/Examples/largerExample.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../");
 bigAssApi.logging = false;
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup

--- a/Examples/largerExample.js
+++ b/Examples/largerExample.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 bigAssApi.logging = false;
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup

--- a/Examples/simpleExample.js
+++ b/Examples/simpleExample.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 

--- a/Examples/simpleExample.js
+++ b/Examples/simpleExample.js
@@ -1,4 +1,4 @@
-var bigAssApi = require("../");
+var bigAssApi = require("../BigAssApi");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 

--- a/Examples/simpleExample.js
+++ b/Examples/simpleExample.js
@@ -1,8 +1,8 @@
-var bigAssApi = require("../BigAssApi");
+var bigAssApi = require("../src/BigAssApi");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 
-myMaster.onFanFullyUpdated = function(myBigAss){
+myMaster.onDeviceFullyUpdated = function(myBigAss){
 
     // Will automatically update / retry setting for this connected fan
     myBigAss.light.brightness = 1;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Unofficial Big Ass API
 ======================
-This is this an unofficial Node.js API for [Big Ass Fans - fans with SenseME](www.bigassfans.com).
-
-In particular - all development was done on a Haiku fan with SenseME.
+This is this an unofficial Node.js API for [Big Ass Fans and lights with SenseME](www.bigassfans.com).
 
 What this could be/is used for
 ------------------------------
@@ -12,28 +10,28 @@ What this could be/is used for
 
 Using the API!
 ==============
-Two major components - the FanMaster and the BigAssFan.
+Three major components - the FanMaster, the BigAssLight, and the BigAssFan.
 
 FanMaster
 ---------
- - Listens for new fans
- - Allows sending messages to all fans
- - Routes all incoming messages to the appropriate child fans
- - Retries fan searching if fans detected < fans specified in constructor
- - Will not search for any fans if 0 is passed into constructor
+ - Listens for new devices
+ - Allows sending messages to all devices
+ - Routes all incoming messages to the appropriate child devices
+ - Retries device searching if devices detected < devices specified in constructor
+ - Will not search for any devices if 0 is passed into constructor
 
 Every fan needs a `FanMaster`! Because that's where the messages come from!
 
 ### Usage
- - Initialize with: `new bigAssApi.FanMaster(numberOfExpectedFans)`
+ - Initialize with: `new bigAssApi.FanMaster(numberOfExpectedDevices)`
  	- Will continue to query for new fans until numberOfExpectedFans is met - default is 1
- - `onFanFullyUpdated` - callback you can override - called with every new fully initialized fan
- - `onFanConnection` - callback you can override - called with every new fan connection with the fan connected
- 	- Will get called before onFanFullyUpdated - but not guaranteed to have all fields updated (some will be `undefined`)
- - `rescanForFans` - rescans for all fans
- - `rescanUntilAllFans` - continues rescanning until `fanMaster.numberOfExpectedFans >= fansFound`
- - `allFans` - dictionary containing all of the fans - keyed off of the user given name
- - `pollingIntervalForFans` - polling interval if `numberOfExpectedFans < fansFound`
+ - `onDeviceFullyUpdated` - callback you can override - called with every new fully initialized device
+ - `onDeviceConnection` - callback you can override - called with every new device connection with the device connected
+ 	- Will get called before `onDeviceFullyUpdated` - but not guaranteed to have all fields updated (some will be `undefined`)
+ - `rescanForDevices` - rescans for all fans
+ - `rescanUntilAllDevices` - continues rescanning until `fanMaster.numberOfExpectedDevices >= fansFound`
+ - `allDevices` - dictionary containing all of the devices - keyed off of the user given name
+ - `pollingIntervalForDevices` - polling interval if `numberOfExpectedDevices < devicesFound`
 
 BigAssFan
 ---------
@@ -56,7 +54,7 @@ var bigAssApi = require("BigAssFansAPI");
 
 var myMaster = new bigAssApi.FanMaster(1); // Expect only one fan in my setup
 
-myMaster.onFanFullyUpdated = function(myBigAss){
+myMaster.onDeviceFullyUpdated = function(myBigAss){
 
     // Will automatically update / retry setting for this connected fan
     myBigAss.light.brightness = 1;

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Every fan needs a `FanMaster`! Because that's where the messages come from!
 
 BigAssFan
 ---------
- - Allows sending and recieving messages from the fan
+ - Allows sending and receiving messages from the fan
  - Registering for property updates
  - Sending update events to a given property
  - Implementing retries on setting properties

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/sean9keenan/BigAssFansAPI.git"
   },
+  "scripts": {
+    "discover": "BIG_ASS_LOG=true node ./Examples/getFanInfo.js"
+  },
   "keywords": [
     "homeautomation"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "BigAssFansAPI",
   "version": "1.1.1",
   "description": "An unofficial API for BigAssFans",
-  "main": "BigAssApi.js",
+  "main": "src/BigAssApi.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/sean9keenan/BigAssFansAPI.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BigAssFansAPI",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "An unofficial API for BigAssFans",
   "main": "src/BigAssApi.js",
   "repository": {

--- a/src/BigAssApi.js
+++ b/src/BigAssApi.js
@@ -6,7 +6,7 @@ const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 
 function FanMaster (numberOfExpectedDevices) {
     this.allDevices = {}; // Dictionary of fan name -> BigAssDevice
-    this.sonnectionOpen = false;
+    this.connectionOpen = false;
     this.fanPort = 31415;
     this.everyone = "255.255.255.255";
     this.server = dgram.createSocket("udp4");

--- a/src/BigAssApi.js
+++ b/src/BigAssApi.js
@@ -56,6 +56,8 @@ function FanMaster (numberOfExpectedFans) {
             newFan.updateAll(function() {
                 this.onFanFullyUpdated(newFan)
             }.bind(this));
+        } else if (deviceType == "LIGHT") {
+
         } else if (deviceType == "SWITCH") {
             myLogWrapper("Skipping wall control - TODO : Add support for wall control")
         } else {
@@ -405,5 +407,5 @@ var myLogWrapper = function(msg) {
 
 exports.FanMaster = FanMaster;
 exports.BigAssFan = BigAssFan;
-exports.logging = false;
+exports.logging = true;
 

--- a/src/BigAssApi.js
+++ b/src/BigAssApi.js
@@ -48,21 +48,21 @@ function FanMaster (numberOfExpectedDevices) {
         this.connectionOpen = false;
     });
 
+    let addDevice = (newDevice) => {
+        this.allDevices[newDevice.name] = newDevice;
+        this.onDeviceConnection(newDevice);
+        newDevice.updateAll(() => this.onDeviceFullyUpdated(newDevice));
+    };
+
     let handleNewDevice = (msg, address) => {
         if (msg[0] == "ALL") {
             return; // Message not addressed to us
         }
         const deviceType = msg[4].split(",",1); // Grab first part of string before ","
         if (deviceType == "FAN") {
-            const newDevice = new BigAssFan(msg[0], msg[3], address, this);
-            this.allDevices[msg[0]] = newDevice;
-            this.onDeviceConnection(newDevice);
-            newDevice.updateAll(() => this.onDeviceFullyUpdated(newDevice));
+            addDevice(new BigAssFan(msg[0], msg[3], address, this));
         } else if (deviceType == "LIGHT") {
-            let newLight = new BigAssLight(msg[0], msg[3], address, this);
-            this.allDevices[msg[0]] = newLight;
-            this.onDeviceConnection(newLight);
-            newLight.updateAll(() => this.onDeviceFullyUpdated(newLight));
+            addDevice(new BigAssLight(msg[0], msg[3], address, this));
         } else if (deviceType == "SWITCH") {
             myLogWrapper("Skipping wall control - TODO : Add support for wall control");
         } else {

--- a/src/BigAssApi.js
+++ b/src/BigAssApi.js
@@ -5,7 +5,7 @@ const BigAssProperty = require('./BigAssProperty');
 const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 
 function FanMaster (numberOfExpectedFans) {
-    this.allFans = {}; // Dictionary of fan name -> BigAssFan
+    this.allDevices = {}; // Dictionary of fan name -> BigAssFan
     this.connectionOpen = false;
     this.fanPort = 31415;
     this.everyone = "255.255.255.255";
@@ -34,7 +34,7 @@ function FanMaster (numberOfExpectedFans) {
 
     this.rescanUntilAllFans = () => {
         const pollForFans = () => {
-            if (Object.keys(this.allFans).length < this.numberOfExpectedFans) {
+            if (Object.keys(this.allDevices).length < this.numberOfExpectedFans) {
                 this.rescanForFans();
             } else {
                 clearInterval(id);
@@ -55,12 +55,12 @@ function FanMaster (numberOfExpectedFans) {
         const deviceType = msg[4].split(",",1); // Grab first part of string before ","
         if (deviceType == "FAN") {
             const newFan = new BigAssFan(msg[0], msg[3], address, this);
-            this.allFans[msg[0]] = newFan;
+            this.allDevices[msg[0]] = newFan;
             this.onFanConnection(newFan);
             newFan.updateAll(() => this.onFanFullyUpdated(newFan));
         } else if (deviceType == "LIGHT") {
             let newLight = new BigAssLight(msg[0], msg[3], address, this);
-            this.allFans[msg[0]] = newLight;
+            this.allDevices[msg[0]] = newLight;
             this.onFanConnection(newLight);
             newLight.updateAll(() => this.onFanFullyUpdated(newLight));
         } else if (deviceType == "SWITCH") {

--- a/src/BigAssApi.js
+++ b/src/BigAssApi.js
@@ -1,7 +1,8 @@
-var dgram = require("dgram");
-var BigAssFan = require('./BigAssFan');
-var BigAssProperty = require('./BigAssProperty');
-var { syncingCallback, retryCall, myLogWrapper } = require('./utils');
+const dgram = require("dgram");
+const BigAssFan = require('./BigAssFan');
+const BigAssLight = require('./BigAssLight');
+const BigAssProperty = require('./BigAssProperty');
+const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 
 function FanMaster (numberOfExpectedFans) {
     this.allFans = {}; // Dictionary of fan name -> BigAssFan
@@ -10,191 +11,83 @@ function FanMaster (numberOfExpectedFans) {
     this.everyone = "255.255.255.255";
     this.server = dgram.createSocket("udp4");
     this.pollingIntervalForFans = 1000;
-    this.dispatchForFans = {}
+    this.dispatchForFans = {};
     this.numberOfExpectedFans = numberOfExpectedFans ? numberOfExpectedFans : 1;
     this.theAllFan = new BigAssFan("ALL", "ALL", this.everyone, this); // If you wanted to broadcast to everyone
 
-    this.onFanConnection = function () {}; // Callback you can register for
-    this.onFanFullyUpdated = function () {}; // Callback you can register for
+    this.onFanConnection = () => {}; // Callback you can register for
+    this.onFanFullyUpdated = () => {}; // Callback you can register for
 
-    this.broadcastToFans = function(message) {
-        this.sendRaw("<ALL;" + message + ">", this.everyone);
-    }.bind(this);
+    this.broadcastToFans = (message) => {
+        this.sendRaw(`<ALL;${message}>`, this.everyone);
+    };
 
-    this.sendRaw = function(message, address) {
-        myLogWrapper("Sending: " + message);
-        var buffMessage = new Buffer(message);
+    this.sendRaw = (message, address) => {
+        myLogWrapper(`Sending: ${message}`);
+        const buffMessage = new Buffer(message);
         this.server.send(buffMessage, 0, buffMessage.length, this.fanPort, address);
-    }.bind(this);
+    };
 
-    this.rescanForFans = function(){
+    this.rescanForFans = () => {
         this.broadcastToFans("DEVICE;ID;GET");
-    }.bind(this)
+    };
 
-    this.rescanUntilAllFans = function(){
-        var pollForFans = function() {
+    this.rescanUntilAllFans = () => {
+        const pollForFans = () => {
             if (Object.keys(this.allFans).length < this.numberOfExpectedFans) {
                 this.rescanForFans();
             } else {
                 clearInterval(id);
             }
-        }.bind(this);
-        var id = setInterval(pollForFans, this.pollingIntervalForFans);
+        };
+        const id = setInterval(pollForFans, this.pollingIntervalForFans);
         pollForFans();
-    }.bind(this)
+    };
 
-    this.server.on('close', function(msg, rinfo) {
+    this.server.on('close', (msg, rinfo) => {
         this.connectionOpen = false;
-    }.bind(this));
+    });
 
-    handleNewFan = function(msg, address) {
+    let handleNewFan = (msg, address) => {
         if (msg[0] == "ALL") {
             return; // Message not addressed to us
         }
-        var deviceType = msg[4].split(",",1); // Grab first part of string before ","
+        const deviceType = msg[4].split(",",1); // Grab first part of string before ","
         if (deviceType == "FAN") {
-            var newFan = new BigAssFan(msg[0], msg[3], address, this);
+            const newFan = new BigAssFan(msg[0], msg[3], address, this);
             this.allFans[msg[0]] = newFan;
             this.onFanConnection(newFan);
-            newFan.updateAll(function() {
-                this.onFanFullyUpdated(newFan)
-            }.bind(this));
+            newFan.updateAll(() => this.onFanFullyUpdated(newFan));
         } else if (deviceType == "LIGHT") {
-
+            let newLight = new BigAssLight(msg[0], msg[3], address, this);
+            this.allFans[msg[0]] = newLight;
+            this.onFanConnection(newLight);
+            newLight.updateAll(() => this.onFanFullyUpdated(newLight));
         } else if (deviceType == "SWITCH") {
-            myLogWrapper("Skipping wall control - TODO : Add support for wall control")
+            myLogWrapper("Skipping wall control - TODO : Add support for wall control");
         } else {
             myLogWrapper("Received message from unknown fan - rescanning");
             this.rescanForFans();
         }
-    }.bind(this)
+    };
 
-    this.server.on("message", (function (msg, rinfo) {
-        myLogWrapper("server got: " + msg + " from " + rinfo.address + ":" + rinfo.port);
-        var splitMessage = ("" + msg).replace(/<|>|\(|\)/g, "").split(";");
-        var fanId = splitMessage.shift();
+    this.server.on("message", (msg, rinfo) => {
+        myLogWrapper(`server got: ${msg} from ${rinfo.address}:${rinfo.port}`);
+        const splitMessage = (`${msg}`).replace(/<|>|\(|\)/g, "").split(";");
+        const fanId = splitMessage.shift();
         if (this.dispatchForFans[fanId]) {
             this.dispatchForFans[fanId](splitMessage);
         } else {
-            splitMessage.unshift(fanId)
+            splitMessage.unshift(fanId);
             handleNewFan(splitMessage, rinfo.address);
         }
-    }).bind(this));
+    });
 
-    this.server.bind(this.fanPort, (function () {
+    this.server.bind(this.fanPort, () => {
         this.server.setBroadcast(true);
         this.connectionOpen = true;
         this.rescanUntilAllFans();
-    }).bind(this));
-}
-
-
-/**
- * Each Big ass fan has a set of properties which in turn have fields
- */
-function BigAssFan (name, id, address, master) {
-    this.name = name;
-    this.id = id ? id : name; // Use the name as the backup if no ID is available
-    this.address = address;
-    this.master = master;
-    this.onPropertyUpdate = undefined;
-
-    this.propertyTable = {};
-    this.propertyListeners = [];
-    this.maxRetries = 10;        // For properties
-    this.waitTimeOnRetry = 250;  // For properties - in ms
-
-    this.fan = new BigAssProperty('fan', this);
-    this.fan.createGetField('isOn', ['FAN', 'PWR'], true, undefined, "ON", "OFF");
-    this.fan.createGetField('speed', ['FAN', 'SPD'], true, 'ACTUAL'); // 0-7 on most fans - can also read min/max 
-    this.fan.createGetField('min', ['FAN', 'SPD'], true, 'MIN');
-    this.fan.createGetField('max', ['FAN', 'SPD'], true, 'MAX');
-    this.fan.createGetField('auto', ['FAN', 'AUTO'], true, undefined, "ON", "OFF"); // Fan sensor enabled
-    this.fan.createGetField('whoosh', ['FAN', 'WHOOSH'], true, "STATUS"); // ON, OFF
-    this.fan.createGetField('isSpinningForwards', ['FAN', 'DIR'], true, undefined, "FWD", "REV");
-
-    this.light = new BigAssProperty('light', this);
-    this.light.createGetField('brightness', ['LIGHT', 'LEVEL'], true, 'ACTUAL'); // 0-16
-    this.light.createGetField('min', ['LIGHT', 'LEVEL'], true, 'MIN');
-    this.light.createGetField('max', ['LIGHT', 'LEVEL'], true, 'MAX');
-    this.light.createGetField('auto', ['LIGHT', 'AUTO'], true, undefined, 'ON', 'OFF'); // Light sensor enabled
-    this.light.createGetField('exists', ['DEVICE', 'LIGHT'], false, undefined, "PRESENT"); // Unknown false string.. WAY too lazy to unplug from fan
-
-    this.sensor = new BigAssProperty('sensor', this);
-    this.sensor.createGetField('isOccupied', ['SNSROCC', 'STATUS'], false, undefined, 'OCCUPIED', 'UNOCCUPIED');
-    this.sensor.createGetField('minTimeout', ['SNSROCC', 'TIMEOUT'], true, 'MIN'); // Seconds (ie 3600000 is 60 min)
-    this.sensor.createGetField('maxTimeout', ['SNSROCC', 'TIMEOUT'], true, 'MAX'); // Seconds
-    this.sensor.createGetField('timeout', ['SNSROCC', 'TIMEOUT'], true, 'CURR');   // Seconds
-
-    this.smartmode = new BigAssProperty('smartmode', this);
-    this.smartmode.createGetField('smartmodeactual', ['SMARTMODE', 'ACTUAL'], true, undefined, 'OFF', 'COOLING', 'HEATING'); // Heating smartmode invokes LEARN;STATE;OFF and FAN;PWR;ON and FAN;SPD;ACTUAL;1 and WINTERMODE;STATE;ON and SMARTMODE;STATE;HEATING and SMARTMODE;ACTUAL;HEATING
-    this.smartmode.createGetField('smartmodestate', ['SMARTMODE', 'STATE'], true, undefined, 'LEARN', 'COOLING', 'HEATING', 'FOLLOWSTAT'); // FOLLOWSTAT is the works with nest option, it is followed by SMARTMODE;ACTUAL;OFF command
-
-    this.learn = new BigAssProperty('learn', this);
-    this.learn.createGetField('isOn', ['LEARN', 'STATE'], true, undefined, 'LEARN', 'OFF'); // LEARN appears to be the on command rather than ON, ie LEARN;STATE;LEARN. When turned on, two or three commands follow, WINTERMODE;STATE;OFF and SMARTMODE;STATE;COOLING and SMARTMODE;ACTUAL;COOLING
-    this.learn.createGetField('minSpeed', ['LEARN', 'MINSPEED'], true);
-    this.learn.createGetField('maxSpeed', ['LEARN', 'MAXSPEED'], true);
-    this.learn.createGetField('zeroTemp', ['LEARN', 'ZEROTEMP'], true); // This is a four digit number that represents the temperature in celsius (without a decimal) at which the fan automatically turns off in smart mode. For instance '2111' is 21.11 C which is 70 F 
-
-    this.sleep = new BigAssProperty('sleep', this);
-    this.sleep.createGetField('isOn', ['SLEEP', 'STATE'], true, undefined, 'ON', 'OFF');
-    this.sleep.createGetField('smartIdealTemp', ['SMARTSLEEP', 'IDEALTEMP'], true);
-    this.sleep.createGetField('minSpeed', ['SMARTSLEEP', 'MINSPEED'], true);
-    this.sleep.createGetField('maxSpeed', ['SMARTSLEEP', 'MAXSPEED'], true);
-
-    this.device = new BigAssProperty('device', this);
-    this.device.createGetField('beeper', ['DEVICE', 'BEEPER'], true, undefined, 'ON', 'OFF');
-    this.device.createGetField('indicators', ['DEVICE', 'INDICATORS'], true, undefined, 'ON', 'OFF');
-    this.device.createGetField('winterMode', ['WINTERMODE', 'STATE'], true, undefined, 'ON', 'OFF');
-    this.device.createGetField('height', ['WINTERMODE', 'HEIGHT'], true); // This is a whole number in meters, like 274 for 9 ft, 244 for 8 ft etc
-    this.device.createGetField('token', ['NW', 'TOKEN'], false); // ??? token for what? reference to api.bigassfans.com in packets
-    this.device.createGetField('dhcp', ['NW', 'DHCP'], true, undefined, 'ON', 'OFF');
-    this.device.createGetField('fw', ['FW', 'FW000003'], false); // What is the FW000003 for in the query?
-    this.device.createGetField('broadcastSSID', ['NW', 'SSID'], true);
-    this.device.createGetField('isAccessPoint', ['NW', 'AP'], true, 'STATUS', 'ON', 'OFF');
-
-
-    // Handles incoming messages from the fanMaster
-    // Property listners are an array of two values
-    //   - (1) : Array of property names to match on response
-    //   - (2) : Callback to run
-    this.handleMessage = function(message) {
-        for (var key in this.propertyListeners) {
-            var propertyListener = this.propertyListeners[key]
-            if (!message || message.length < propertyListener[0].length) {
-                continue;
-            }
-            var isSubset = true;
-            for (var i = 0; i < propertyListener[0].length; i++) {
-                if (propertyListener[0][i] != message[i]) {
-                    isSubset = false;
-                    break;
-                }
-            };
-            if (isSubset) {
-                propertyListener[1](message[i]);
-            }
-        }
-    }.bind(this)
-
-    this.master.dispatchForFans[name] = this.handleMessage;
-    this.master.dispatchForFans[id] = this.handleMessage;
-
-    this.updateAll = function(callback) {
-        var syncCallback = syncingCallback(this.propertyTable, callback);
-        for (var propertyKey in this.propertyTable) {
-            this.propertyTable[propertyKey].updateAll(syncCallback);
-        }
-    }.bind(this)
-
-    this.update = function(property, callback) {
-        this[property].updateAll(callback)
-    }.bind(this)
-
-    this.send = function(msg) {
-        var toSend = [this.id].concat(msg).join(";");
-        this.master.sendRaw("<" + toSend + ">", address);
-    }.bind(this)
+    });
 }
 
 exports.FanMaster = FanMaster;

--- a/src/BigAssFan.js
+++ b/src/BigAssFan.js
@@ -1,7 +1,7 @@
-var BigAssProperty = require('./BigAssProperty');
-var { syncingCallback, retryCall, myLogWrapper } = require('./utils');
+const BigAssProperty = require('./BigAssProperty');
+const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 
-function BigAssFan (name, id, address, master) {
+module.exports = function BigAssFan (name, id, address, master) {
     this.name = name;
     this.id = id ? id : name; // Use the name as the backup if no ID is available
     this.address = address;
@@ -67,13 +67,13 @@ function BigAssFan (name, id, address, master) {
     // Property listners are an array of two values
     //   - (1) : Array of property names to match on response
     //   - (2) : Callback to run
-    this.handleMessage = function(message) {
-        for (var key in this.propertyListeners) {
-            var propertyListener = this.propertyListeners[key]
+    this.handleMessage = message => {
+        for (const key in this.propertyListeners) {
+            const propertyListener = this.propertyListeners[key];
             if (!message || message.length < propertyListener[0].length) {
                 continue;
             }
-            var isSubset = true;
+            let isSubset = true;
             for (var i = 0; i < propertyListener[0].length; i++) {
                 if (propertyListener[0][i] != message[i]) {
                     isSubset = false;
@@ -84,26 +84,24 @@ function BigAssFan (name, id, address, master) {
                 propertyListener[1](message[i]);
             }
         }
-    }.bind(this)
+    }
 
     this.master.dispatchForFans[name] = this.handleMessage;
     this.master.dispatchForFans[id] = this.handleMessage;
 
-    this.updateAll = function(callback) {
-        var syncCallback = syncingCallback(this.propertyTable, callback);
-        for (var propertyKey in this.propertyTable) {
+    this.updateAll = callback => {
+        const syncCallback = syncingCallback(this.propertyTable, callback);
+        for (const propertyKey in this.propertyTable) {
             this.propertyTable[propertyKey].updateAll(syncCallback);
         }
-    }.bind(this)
+    }
 
-    this.update = function(property, callback) {
+    this.update = (property, callback) => {
         this[property].updateAll(callback)
-    }.bind(this)
+    }
 
-    this.send = function(msg) {
-        var toSend = [this.id].concat(msg).join(";");
-        this.master.sendRaw("<" + toSend + ">", address);
-    }.bind(this)
-}
-
-module.exports = BigAssFan;
+    this.send = msg => {
+        const toSend = [this.id].concat(msg).join(";");
+        this.master.sendRaw(`<${toSend}>`, address);
+    }
+};

--- a/src/BigAssFan.js
+++ b/src/BigAssFan.js
@@ -86,8 +86,8 @@ module.exports = function BigAssFan (name, id, address, master) {
         }
     }
 
-    this.master.dispatchForFans[name] = this.handleMessage;
-    this.master.dispatchForFans[id] = this.handleMessage;
+    this.master.dispatchForDevices[name] = this.handleMessage;
+    this.master.dispatchForDevices[id] = this.handleMessage;
 
     this.updateAll = callback => {
         const syncCallback = syncingCallback(this.propertyTable, callback);

--- a/src/BigAssFan.js
+++ b/src/BigAssFan.js
@@ -1,97 +1,6 @@
-var dgram = require("dgram");
-var BigAssFan = require('./BigAssFan');
 var BigAssProperty = require('./BigAssProperty');
 var { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 
-function FanMaster (numberOfExpectedFans) {
-    this.allFans = {}; // Dictionary of fan name -> BigAssFan
-    this.connectionOpen = false;
-    this.fanPort = 31415;
-    this.everyone = "255.255.255.255";
-    this.server = dgram.createSocket("udp4");
-    this.pollingIntervalForFans = 1000;
-    this.dispatchForFans = {}
-    this.numberOfExpectedFans = numberOfExpectedFans ? numberOfExpectedFans : 1;
-    this.theAllFan = new BigAssFan("ALL", "ALL", this.everyone, this); // If you wanted to broadcast to everyone
-
-    this.onFanConnection = function () {}; // Callback you can register for
-    this.onFanFullyUpdated = function () {}; // Callback you can register for
-
-    this.broadcastToFans = function(message) {
-        this.sendRaw("<ALL;" + message + ">", this.everyone);
-    }.bind(this);
-
-    this.sendRaw = function(message, address) {
-        myLogWrapper("Sending: " + message);
-        var buffMessage = new Buffer(message);
-        this.server.send(buffMessage, 0, buffMessage.length, this.fanPort, address);
-    }.bind(this);
-
-    this.rescanForFans = function(){
-        this.broadcastToFans("DEVICE;ID;GET");
-    }.bind(this)
-
-    this.rescanUntilAllFans = function(){
-        var pollForFans = function() {
-            if (Object.keys(this.allFans).length < this.numberOfExpectedFans) {
-                this.rescanForFans();
-            } else {
-                clearInterval(id);
-            }
-        }.bind(this);
-        var id = setInterval(pollForFans, this.pollingIntervalForFans);
-        pollForFans();
-    }.bind(this)
-
-    this.server.on('close', function(msg, rinfo) {
-        this.connectionOpen = false;
-    }.bind(this));
-
-    handleNewFan = function(msg, address) {
-        if (msg[0] == "ALL") {
-            return; // Message not addressed to us
-        }
-        var deviceType = msg[4].split(",",1); // Grab first part of string before ","
-        if (deviceType == "FAN") {
-            var newFan = new BigAssFan(msg[0], msg[3], address, this);
-            this.allFans[msg[0]] = newFan;
-            this.onFanConnection(newFan);
-            newFan.updateAll(function() {
-                this.onFanFullyUpdated(newFan)
-            }.bind(this));
-        } else if (deviceType == "LIGHT") {
-
-        } else if (deviceType == "SWITCH") {
-            myLogWrapper("Skipping wall control - TODO : Add support for wall control")
-        } else {
-            myLogWrapper("Received message from unknown fan - rescanning");
-            this.rescanForFans();
-        }
-    }.bind(this)
-
-    this.server.on("message", (function (msg, rinfo) {
-        myLogWrapper("server got: " + msg + " from " + rinfo.address + ":" + rinfo.port);
-        var splitMessage = ("" + msg).replace(/<|>|\(|\)/g, "").split(";");
-        var fanId = splitMessage.shift();
-        if (this.dispatchForFans[fanId]) {
-            this.dispatchForFans[fanId](splitMessage);
-        } else {
-            splitMessage.unshift(fanId)
-            handleNewFan(splitMessage, rinfo.address);
-        }
-    }).bind(this));
-
-    this.server.bind(this.fanPort, (function () {
-        this.server.setBroadcast(true);
-        this.connectionOpen = true;
-        this.rescanUntilAllFans();
-    }).bind(this));
-}
-
-
-/**
- * Each Big ass fan has a set of properties which in turn have fields
- */
 function BigAssFan (name, id, address, master) {
     this.name = name;
     this.id = id ? id : name; // Use the name as the backup if no ID is available
@@ -106,7 +15,7 @@ function BigAssFan (name, id, address, master) {
 
     this.fan = new BigAssProperty('fan', this);
     this.fan.createGetField('isOn', ['FAN', 'PWR'], true, undefined, "ON", "OFF");
-    this.fan.createGetField('speed', ['FAN', 'SPD'], true, 'ACTUAL'); // 0-7 on most fans - can also read min/max 
+    this.fan.createGetField('speed', ['FAN', 'SPD'], true, 'ACTUAL'); // 0-7 on most fans - can also read min/max
     this.fan.createGetField('min', ['FAN', 'SPD'], true, 'MIN');
     this.fan.createGetField('max', ['FAN', 'SPD'], true, 'MAX');
     this.fan.createGetField('auto', ['FAN', 'AUTO'], true, undefined, "ON", "OFF"); // Fan sensor enabled
@@ -134,7 +43,7 @@ function BigAssFan (name, id, address, master) {
     this.learn.createGetField('isOn', ['LEARN', 'STATE'], true, undefined, 'LEARN', 'OFF'); // LEARN appears to be the on command rather than ON, ie LEARN;STATE;LEARN. When turned on, two or three commands follow, WINTERMODE;STATE;OFF and SMARTMODE;STATE;COOLING and SMARTMODE;ACTUAL;COOLING
     this.learn.createGetField('minSpeed', ['LEARN', 'MINSPEED'], true);
     this.learn.createGetField('maxSpeed', ['LEARN', 'MAXSPEED'], true);
-    this.learn.createGetField('zeroTemp', ['LEARN', 'ZEROTEMP'], true); // This is a four digit number that represents the temperature in celsius (without a decimal) at which the fan automatically turns off in smart mode. For instance '2111' is 21.11 C which is 70 F 
+    this.learn.createGetField('zeroTemp', ['LEARN', 'ZEROTEMP'], true); // This is a four digit number that represents the temperature in celsius (without a decimal) at which the fan automatically turns off in smart mode. For instance '2111' is 21.11 C which is 70 F
 
     this.sleep = new BigAssProperty('sleep', this);
     this.sleep.createGetField('isOn', ['SLEEP', 'STATE'], true, undefined, 'ON', 'OFF');
@@ -197,5 +106,4 @@ function BigAssFan (name, id, address, master) {
     }.bind(this)
 }
 
-exports.FanMaster = FanMaster;
-exports.BigAssFan = BigAssFan;
+module.exports = BigAssFan;

--- a/src/BigAssLight.js
+++ b/src/BigAssLight.js
@@ -86,8 +86,8 @@ module.exports = function BigAssLight (name, id, address, master) {
         }
     }
 
-    this.master.dispatchForFans[name] = this.handleMessage;
-    this.master.dispatchForFans[id] = this.handleMessage;
+    this.master.dispatchForDevices[name] = this.handleMessage;
+    this.master.dispatchForDevices[id] = this.handleMessage;
 
     this.updateAll = callback => {
         const syncCallback = syncingCallback(this.propertyTable, callback);

--- a/src/BigAssLight.js
+++ b/src/BigAssLight.js
@@ -1,0 +1,107 @@
+const BigAssProperty = require('./BigAssProperty');
+const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
+
+module.exports = function BigAssLight (name, id, address, master) {
+    this.name = name;
+    this.id = id ? id : name; // Use the name as the backup if no ID is available
+    this.address = address;
+    this.master = master;
+    this.onPropertyUpdate = undefined;
+
+    this.propertyTable = {};
+    this.propertyListeners = [];
+    this.maxRetries = 10;        // For properties
+    this.waitTimeOnRetry = 250;  // For properties - in ms
+
+    this.fan = new BigAssProperty('fan', this);
+    this.fan.createGetField('isOn', ['FAN', 'PWR'], true, undefined, "ON", "OFF");
+    this.fan.createGetField('speed', ['FAN', 'SPD'], true, 'ACTUAL'); // 0-7 on most fans - can also read min/max
+    this.fan.createGetField('min', ['FAN', 'SPD'], true, 'MIN');
+    this.fan.createGetField('max', ['FAN', 'SPD'], true, 'MAX');
+    this.fan.createGetField('auto', ['FAN', 'AUTO'], true, undefined, "ON", "OFF"); // Fan sensor enabled
+    this.fan.createGetField('whoosh', ['FAN', 'WHOOSH'], true, "STATUS"); // ON, OFF
+    this.fan.createGetField('isSpinningForwards', ['FAN', 'DIR'], true, undefined, "FWD", "REV");
+
+    this.light = new BigAssProperty('light', this);
+    this.light.createGetField('brightness', ['LIGHT', 'LEVEL'], true, 'ACTUAL'); // 0-16
+    this.light.createGetField('min', ['LIGHT', 'LEVEL'], true, 'MIN');
+    this.light.createGetField('max', ['LIGHT', 'LEVEL'], true, 'MAX');
+    this.light.createGetField('auto', ['LIGHT', 'AUTO'], true, undefined, 'ON', 'OFF'); // Light sensor enabled
+    this.light.createGetField('exists', ['DEVICE', 'LIGHT'], false, undefined, "PRESENT"); // Unknown false string.. WAY too lazy to unplug from fan
+
+    this.sensor = new BigAssProperty('sensor', this);
+    this.sensor.createGetField('isOccupied', ['SNSROCC', 'STATUS'], false, undefined, 'OCCUPIED', 'UNOCCUPIED');
+    this.sensor.createGetField('minTimeout', ['SNSROCC', 'TIMEOUT'], true, 'MIN'); // Seconds (ie 3600000 is 60 min)
+    this.sensor.createGetField('maxTimeout', ['SNSROCC', 'TIMEOUT'], true, 'MAX'); // Seconds
+    this.sensor.createGetField('timeout', ['SNSROCC', 'TIMEOUT'], true, 'CURR');   // Seconds
+
+    this.smartmode = new BigAssProperty('smartmode', this);
+    this.smartmode.createGetField('smartmodeactual', ['SMARTMODE', 'ACTUAL'], true, undefined, 'OFF', 'COOLING', 'HEATING'); // Heating smartmode invokes LEARN;STATE;OFF and FAN;PWR;ON and FAN;SPD;ACTUAL;1 and WINTERMODE;STATE;ON and SMARTMODE;STATE;HEATING and SMARTMODE;ACTUAL;HEATING
+    this.smartmode.createGetField('smartmodestate', ['SMARTMODE', 'STATE'], true, undefined, 'LEARN', 'COOLING', 'HEATING', 'FOLLOWSTAT'); // FOLLOWSTAT is the works with nest option, it is followed by SMARTMODE;ACTUAL;OFF command
+
+    this.learn = new BigAssProperty('learn', this);
+    this.learn.createGetField('isOn', ['LEARN', 'STATE'], true, undefined, 'LEARN', 'OFF'); // LEARN appears to be the on command rather than ON, ie LEARN;STATE;LEARN. When turned on, two or three commands follow, WINTERMODE;STATE;OFF and SMARTMODE;STATE;COOLING and SMARTMODE;ACTUAL;COOLING
+    this.learn.createGetField('minSpeed', ['LEARN', 'MINSPEED'], true);
+    this.learn.createGetField('maxSpeed', ['LEARN', 'MAXSPEED'], true);
+    this.learn.createGetField('zeroTemp', ['LEARN', 'ZEROTEMP'], true); // This is a four digit number that represents the temperature in celsius (without a decimal) at which the fan automatically turns off in smart mode. For instance '2111' is 21.11 C which is 70 F
+
+    this.sleep = new BigAssProperty('sleep', this);
+    this.sleep.createGetField('isOn', ['SLEEP', 'STATE'], true, undefined, 'ON', 'OFF');
+    this.sleep.createGetField('smartIdealTemp', ['SMARTSLEEP', 'IDEALTEMP'], true);
+    this.sleep.createGetField('minSpeed', ['SMARTSLEEP', 'MINSPEED'], true);
+    this.sleep.createGetField('maxSpeed', ['SMARTSLEEP', 'MAXSPEED'], true);
+
+    this.device = new BigAssProperty('device', this);
+    this.device.createGetField('beeper', ['DEVICE', 'BEEPER'], true, undefined, 'ON', 'OFF');
+    this.device.createGetField('indicators', ['DEVICE', 'INDICATORS'], true, undefined, 'ON', 'OFF');
+    this.device.createGetField('winterMode', ['WINTERMODE', 'STATE'], true, undefined, 'ON', 'OFF');
+    this.device.createGetField('height', ['WINTERMODE', 'HEIGHT'], true); // This is a whole number in meters, like 274 for 9 ft, 244 for 8 ft etc
+    this.device.createGetField('token', ['NW', 'TOKEN'], false); // ??? token for what? reference to api.bigassfans.com in packets
+    this.device.createGetField('dhcp', ['NW', 'DHCP'], true, undefined, 'ON', 'OFF');
+    this.device.createGetField('fw', ['FW', 'FW000003'], false); // What is the FW000003 for in the query?
+    this.device.createGetField('broadcastSSID', ['NW', 'SSID'], true);
+    this.device.createGetField('isAccessPoint', ['NW', 'AP'], true, 'STATUS', 'ON', 'OFF');
+
+
+    // Handles incoming messages from the fanMaster
+    // Property listners are an array of two values
+    //   - (1) : Array of property names to match on response
+    //   - (2) : Callback to run
+    this.handleMessage = message => {
+        for (const key in this.propertyListeners) {
+            const propertyListener = this.propertyListeners[key];
+            if (!message || message.length < propertyListener[0].length) {
+                continue;
+            }
+            let isSubset = true;
+            for (var i = 0; i < propertyListener[0].length; i++) {
+                if (propertyListener[0][i] != message[i]) {
+                    isSubset = false;
+                    break;
+                }
+            };
+            if (isSubset) {
+                propertyListener[1](message[i]);
+            }
+        }
+    }
+
+    this.master.dispatchForFans[name] = this.handleMessage;
+    this.master.dispatchForFans[id] = this.handleMessage;
+
+    this.updateAll = callback => {
+        const syncCallback = syncingCallback(this.propertyTable, callback);
+        for (const propertyKey in this.propertyTable) {
+            this.propertyTable[propertyKey].updateAll(syncCallback);
+        }
+    }
+
+    this.update = (property, callback) => {
+        this[property].updateAll(callback)
+    }
+
+    this.send = msg => {
+        const toSend = [this.id].concat(msg).join(";");
+        this.master.sendRaw(`<${toSend}>`, address);
+    }
+};

--- a/src/BigAssProperty.js
+++ b/src/BigAssProperty.js
@@ -1,4 +1,4 @@
-var { syncingCallback, retryCall, myLogWrapper } = require('./utils');
+const { syncingCallback, retryCall, myLogWrapper } = require('./utils');
 module.exports = function BigAssProperty (name, bigAssFan) {
     this.name = name;
     this.bigAssFan = bigAssFan;
@@ -8,49 +8,49 @@ module.exports = function BigAssProperty (name, bigAssFan) {
 
     this.setFunctions = {}
 
-    this.createGetField = function(name, query, isSettable, additionalProp, trueOpt, falseOpt, optionalFilter) {
-        var toSendOnUpdate = query.concat("GET");
+    this.createGetField = (name, query, isSettable, additionalProp, trueOpt, falseOpt, optionalFilter) => {
+        let toSendOnUpdate = query.concat("GET");
         toSendOnUpdate = additionalProp ? toSendOnUpdate.concat(additionalProp) : toSendOnUpdate;
         this.allFieldsUpdateQuery[name] = toSendOnUpdate;
         this.updateCallbacks[name] = {};
 
-        var privateVarName = '_' + name;
+        const privateVarName = `_${name}`;
         this[privateVarName] = undefined;
 
-        var setFunction = function(value, optionalCallback) {
+        const setFunction = (value, optionalCallback) => {
             // TODO ensure that value fits in "filter"
             if (typeof value == "boolean" && trueOpt && falseOpt) {
                 value = value ? trueOpt : falseOpt;
             }
-            var successfullyUpdated = false;
-            var updateTableId = this.registerUpdateCallback(name, function() {
+            let successfullyUpdated = false;
+            const updateTableId = this.registerUpdateCallback(name, () => {
                 successfullyUpdated = true;
                 if (optionalCallback) {
                     optionalCallback(null);
                     optionalCallback = null;
                 }
                 this.unregisterUpdateCallback(name, updateTableId);
-            }.bind(this))
+            });
 
-            var toSetProperty = function () {
+            const toSetProperty = () => {
                 this.bigAssFan.send(query.concat("SET", value))
-            }.bind(this)
+            };
 
-            var isSuccesfullyUpdated = function() {
+            const isSuccesfullyUpdated = function() {
                 return successfullyUpdated;
-            }
+            };
 
-            var isRetriesAllFailed = function() {
+            const isRetriesAllFailed = function() {
                 if (optionalCallback) {
                     optionalCallback(new Error("Failed to set property"));
                     optionalCallback = null; // TODO: Figure out why this is getting called twice in the first place
                                              // Espeicially this this fix can still crash
                 }
-            }
+            };
 
             retryCall(this.bigAssFan.maxRetries, this.bigAssFan.waitTimeOnRetry, toSetProperty, isSuccesfullyUpdated, isRetriesAllFailed);
 
-        }.bind(this)
+        };
 
         this.setFunctions[name] = setFunction;
 
@@ -61,7 +61,7 @@ module.exports = function BigAssProperty (name, bigAssFan) {
             set: isSettable ? setFunction : undefined
         });
 
-        var handleUpdatedValue = function(value) {
+        const handleUpdatedValue = value => {
             if (trueOpt) {
                 this[privateVarName] = (value == trueOpt) ? true : (value == falseOpt || falseOpt == undefined ? false : value);
             } else {
@@ -70,15 +70,15 @@ module.exports = function BigAssProperty (name, bigAssFan) {
             if (this.bigAssFan.onPropertyUpdate) {
                 this.bigAssFan.onPropertyUpdate([this.name, name], value);
             }
-            for (var key in this.updateCallbacks[name]) {
+            for (const key in this.updateCallbacks[name]) {
                 this.updateCallbacks[name][key](value);
             }
-        }.bind(this)
+        };
 
-        var expectedRecieve = additionalProp ? query.concat(additionalProp) : query;
-        this.bigAssFan.propertyListeners[this.name + "." + name] = [expectedRecieve, handleUpdatedValue];
+        const expectedRecieve = additionalProp ? query.concat(additionalProp) : query;
+        this.bigAssFan.propertyListeners[`${this.name}.${name}`] = [expectedRecieve, handleUpdatedValue];
 
-    }.bind(this)
+    }
 
     /**
      * Set a specific property by name
@@ -86,65 +86,65 @@ module.exports = function BigAssProperty (name, bigAssFan) {
      * @param value    - Value to set to this property
      * @param callback - Optional callback, null if success, error otherwise
      */
-    this.setProperty = function(name, value, callback) {
-        var thisSetFunction = this.setFunctions[name]
+    this.setProperty = (name, value, callback) => {
+        const thisSetFunction = this.setFunctions[name];
         if (thisSetFunction) {
             thisSetFunction(value, callback)
         }
-    }.bind(this);
+    };
 
     /**
      * Register an update callback
      * @param name     - Property name to register for a callback on
      * @param callback - Callback, first arg is error (null if none), second is value
      */
-    this.update = function(name, callback) {
-        var updated = false;
-        var id = this.registerUpdateCallback(name, function (value){
+    this.update = (name, callback) => {
+        let updated = false;
+        const id = this.registerUpdateCallback(name, value => {
             updated = true;
             this.unregisterUpdateCallback(name, id);
             if (callback) {
                 callback(null, value);
             }
-        }.bind(this));
+        });
 
-        var functionToRequestUpdate = function() {
+        const functionToRequestUpdate = () => {
             this.bigAssFan.send(this.allFieldsUpdateQuery[name]);
-        }.bind(this)
+        };
 
-        var isUpdateSucceeded = function() { return updated; }
+        const isUpdateSucceeded = function() { return updated; };
 
-        var updateFailed = function() {
+        const updateFailed = function() {
             if (callback) {
                 callback(new Error("Cannot reach fan / property"), null);
             }
-        }
+        };
 
         retryCall(this.bigAssFan.maxRetries, this.bigAssFan.waitTimeOnRetry, functionToRequestUpdate, isUpdateSucceeded, updateFailed);
-    }.bind(this)
+    }
 
-    this.updateAll = function(callback) {
-        var syncCallback = syncingCallback(this.allFieldsUpdateQuery, callback);
-        for (var fieldKey in this.allFieldsUpdateQuery) {
+    this.updateAll = callback => {
+        const syncCallback = syncingCallback(this.allFieldsUpdateQuery, callback);
+        for (const fieldKey in this.allFieldsUpdateQuery) {
             this.update(fieldKey, syncCallback);
         }
-    }.bind(this)
+    }
 
-    this.registerUpdateCallback = function(name, callback) {
+    this.registerUpdateCallback = (name, callback) => {
         do {
             possibleKey = Math.random()
         } while (this.updateCallbacks[name][possibleKey] != undefined);
         this.updateCallbacks[name][possibleKey] = callback;
         return possibleKey;
-    }.bind(this)
+    }
 
-    this.unregisterUpdateCallback = function(name, identifier) {
+    this.unregisterUpdateCallback = (name, identifier) => {
         if (this.updateCallbacks[name][identifier]) {
             delete this.updateCallbacks[name][identifier];
             return true
         }
         return false
-    }.bind(this)
+    }
 
     this.bigAssFan.propertyTable[name] = this;
 }

--- a/src/BigAssProperty.js
+++ b/src/BigAssProperty.js
@@ -1,0 +1,150 @@
+var { syncingCallback, retryCall, myLogWrapper } = require('./utils');
+module.exports = function BigAssProperty (name, bigAssFan) {
+    this.name = name;
+    this.bigAssFan = bigAssFan;
+
+    this.allFieldsUpdateQuery = {}
+    this.updateCallbacks = {}
+
+    this.setFunctions = {}
+
+    this.createGetField = function(name, query, isSettable, additionalProp, trueOpt, falseOpt, optionalFilter) {
+        var toSendOnUpdate = query.concat("GET");
+        toSendOnUpdate = additionalProp ? toSendOnUpdate.concat(additionalProp) : toSendOnUpdate;
+        this.allFieldsUpdateQuery[name] = toSendOnUpdate;
+        this.updateCallbacks[name] = {};
+
+        var privateVarName = '_' + name;
+        this[privateVarName] = undefined;
+
+        var setFunction = function(value, optionalCallback) {
+            // TODO ensure that value fits in "filter"
+            if (typeof value == "boolean" && trueOpt && falseOpt) {
+                value = value ? trueOpt : falseOpt;
+            }
+            var successfullyUpdated = false;
+            var updateTableId = this.registerUpdateCallback(name, function() {
+                successfullyUpdated = true;
+                if (optionalCallback) {
+                    optionalCallback(null);
+                    optionalCallback = null;
+                }
+                this.unregisterUpdateCallback(name, updateTableId);
+            }.bind(this))
+
+            var toSetProperty = function () {
+                this.bigAssFan.send(query.concat("SET", value))
+            }.bind(this)
+
+            var isSuccesfullyUpdated = function() {
+                return successfullyUpdated;
+            }
+
+            var isRetriesAllFailed = function() {
+                if (optionalCallback) {
+                    optionalCallback(new Error("Failed to set property"));
+                    optionalCallback = null; // TODO: Figure out why this is getting called twice in the first place
+                                             // Espeicially this this fix can still crash
+                }
+            }
+
+            retryCall(this.bigAssFan.maxRetries, this.bigAssFan.waitTimeOnRetry, toSetProperty, isSuccesfullyUpdated, isRetriesAllFailed);
+
+        }.bind(this)
+
+        this.setFunctions[name] = setFunction;
+
+        Object.defineProperty(this, name, {
+            get: function() {
+                    return this[privateVarName];
+                },
+            set: isSettable ? setFunction : undefined
+        });
+
+        var handleUpdatedValue = function(value) {
+            if (trueOpt) {
+                this[privateVarName] = (value == trueOpt) ? true : (value == falseOpt || falseOpt == undefined ? false : value);
+            } else {
+                this[privateVarName] = value;
+            }
+            if (this.bigAssFan.onPropertyUpdate) {
+                this.bigAssFan.onPropertyUpdate([this.name, name], value);
+            }
+            for (var key in this.updateCallbacks[name]) {
+                this.updateCallbacks[name][key](value);
+            }
+        }.bind(this)
+
+        var expectedRecieve = additionalProp ? query.concat(additionalProp) : query;
+        this.bigAssFan.propertyListeners[this.name + "." + name] = [expectedRecieve, handleUpdatedValue];
+
+    }.bind(this)
+
+    /**
+     * Set a specific property by name
+     * @param name     - Property name to set
+     * @param value    - Value to set to this property
+     * @param callback - Optional callback, null if success, error otherwise
+     */
+    this.setProperty = function(name, value, callback) {
+        var thisSetFunction = this.setFunctions[name]
+        if (thisSetFunction) {
+            thisSetFunction(value, callback)
+        }
+    }.bind(this);
+
+    /**
+     * Register an update callback
+     * @param name     - Property name to register for a callback on
+     * @param callback - Callback, first arg is error (null if none), second is value
+     */
+    this.update = function(name, callback) {
+        var updated = false;
+        var id = this.registerUpdateCallback(name, function (value){
+            updated = true;
+            this.unregisterUpdateCallback(name, id);
+            if (callback) {
+                callback(null, value);
+            }
+        }.bind(this));
+
+        var functionToRequestUpdate = function() {
+            this.bigAssFan.send(this.allFieldsUpdateQuery[name]);
+        }.bind(this)
+
+        var isUpdateSucceeded = function() { return updated; }
+
+        var updateFailed = function() {
+            if (callback) {
+                callback(new Error("Cannot reach fan / property"), null);
+            }
+        }
+
+        retryCall(this.bigAssFan.maxRetries, this.bigAssFan.waitTimeOnRetry, functionToRequestUpdate, isUpdateSucceeded, updateFailed);
+    }.bind(this)
+
+    this.updateAll = function(callback) {
+        var syncCallback = syncingCallback(this.allFieldsUpdateQuery, callback);
+        for (var fieldKey in this.allFieldsUpdateQuery) {
+            this.update(fieldKey, syncCallback);
+        }
+    }.bind(this)
+
+    this.registerUpdateCallback = function(name, callback) {
+        do {
+            possibleKey = Math.random()
+        } while (this.updateCallbacks[name][possibleKey] != undefined);
+        this.updateCallbacks[name][possibleKey] = callback;
+        return possibleKey;
+    }.bind(this)
+
+    this.unregisterUpdateCallback = function(name, identifier) {
+        if (this.updateCallbacks[name][identifier]) {
+            delete this.updateCallbacks[name][identifier];
+            return true
+        }
+        return false
+    }.bind(this)
+
+    this.bigAssFan.propertyTable[name] = this;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,14 +6,14 @@
  * called these N times it will call the passed in callback
  */
 function syncingCallback (tableBeingUpdated, callback) {
-    var callCount = 0;
-    var lengthOfTable = Object.keys(tableBeingUpdated).length;
+    let callCount = 0;
+    const lengthOfTable = Object.keys(tableBeingUpdated).length;
 
-    var callbackForUser = function() {
+    const callbackForUser = function() {
         if (++callCount == lengthOfTable) {
             callback();
         }
-    }
+    };
 
     return callback ? callbackForUser : undefined;
 }
@@ -27,31 +27,31 @@ function syncingCallback (tableBeingUpdated, callback) {
  * @param isSuccess       - Function to call to check if retry was successful (Returns true/false)
  * @param isFailure       - Function to call if all retries were a failure
  */
-var retryCall = function(maxRetries, waitTimeOnRetry, toCall, isSuccess, isFailure) {
-    var tried = 0;
-    var retry = function() {
+const retryCall = function(maxRetries, waitTimeOnRetry, toCall, isSuccess, isFailure) {
+    let tried = 0;
+    const retry = function() {
         if (!isSuccess()) {
             if (++tried >= maxRetries) {
                 myLogWrapper("Failed - no more retries left");
                 clearInterval(id);
                 isFailure();
             } else {
-                myLogWrapper("Failed - retrying : " + tried);
+                myLogWrapper(`Failed - retrying : ${tried}`);
                 toCall();
             }
         } else {
             clearInterval(id);
         }
     }.bind(this.bigAssFan);
-    var id = setInterval(retry, waitTimeOnRetry);
+    const id = setInterval(retry, waitTimeOnRetry);
     toCall();
-}
+};
 
 /**
  * Simple logging wrapper so that logging can be turned on/off
  */
 var myLogWrapper = function(msg) {
-    var logging = process.env['BIG_ASS_LOG'] === "true";
+    const logging = process.env['BIG_ASS_LOG'] === "true";
     if (logging) {
         console.log(msg);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,64 @@
+
+/**
+ * This function supplies a callback which can be called
+ * N times, where N is the number of elements in
+ * tableBeingUpdated. Once this supplied callback has been
+ * called these N times it will call the passed in callback
+ */
+function syncingCallback (tableBeingUpdated, callback) {
+    var callCount = 0;
+    var lengthOfTable = Object.keys(tableBeingUpdated).length;
+
+    var callbackForUser = function() {
+        if (++callCount == lengthOfTable) {
+            callback();
+        }
+    }
+
+    return callback ? callbackForUser : undefined;
+}
+
+/**
+ * Will retry a given call until success or failure
+ *
+ * @param maxRetries      - Maximum number of retries
+ * @param waitTimeOnRetry - Time between each retry
+ * @param toCall          - Function to call as a part of each retry
+ * @param isSuccess       - Function to call to check if retry was successful (Returns true/false)
+ * @param isFailure       - Function to call if all retries were a failure
+ */
+var retryCall = function(maxRetries, waitTimeOnRetry, toCall, isSuccess, isFailure) {
+    var tried = 0;
+    var retry = function() {
+        if (!isSuccess()) {
+            if (++tried >= maxRetries) {
+                myLogWrapper("Failed - no more retries left");
+                clearInterval(id);
+                isFailure();
+            } else {
+                myLogWrapper("Failed - retrying : " + tried);
+                toCall();
+            }
+        } else {
+            clearInterval(id);
+        }
+    }.bind(this.bigAssFan);
+    var id = setInterval(retry, waitTimeOnRetry);
+    toCall();
+}
+
+/**
+ * Simple logging wrapper so that logging can be turned on/off
+ */
+var myLogWrapper = function(msg) {
+    var logging = process.env['BIG_ASS_LOG'] === "true";
+    if (logging) {
+        console.log(msg);
+    }
+};
+
+module.exports = {
+    myLogWrapper,
+    retryCall,
+    syncingCallback
+};


### PR DESCRIPTION
Ok, working on updates from what @stabbylambda started. I know there were concerns about having significant changes to the API, but with my experience working at Nest, this is for the best. It is likely that Big Ass Inc will expand into more products, and switching to generic terms sooner will make the overall API cleaner in the future.

I verified the examples with my three devices (one fan/light and two standalone lights) and everything is working as expected. Ideally there would be support for identifying device type, but I am going to hold off on that until I look at the Homebridge side of things.

As for Homebridge, I have already create a [PR](https://github.com/sean9keenan/homebridge-bigAssFans/pull/19) to update the plugin so it will lock to the appropriate version of the API module. The sooner that can ship the better.